### PR TITLE
Get compiling on Rust stable and update libs, Fix #1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsdl"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Idiomatic Rust wrapper for WSDL"
 keywords = ["wsdl"]
@@ -12,9 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roxmltree = "0.18"
-thiserror = "1.0.44"
+roxmltree = "0.20"
+thiserror = "1.0.63"
 
 [dev-dependencies]
-anyhow = "1.0.72"
-clap = "4.3"
+anyhow = "1.0.87"
+clap = "4.5.17"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rust newtypes to expose a native interface for reading WSDL files.
 ## Usage
 ```rust
 # use anyhow::Result;
-use wsdl::Wsdl;
+use wsdl::WsDefinitions;
 
 fn example() -> Result<()> {
     let input = std::fs::read_to_string("/path/to/my/service.wsdl")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![feature(try_find)]
 mod wsdl;
 
 pub use self::wsdl::{

--- a/src/wsdl.rs
+++ b/src/wsdl.rs
@@ -335,14 +335,16 @@ impl<'a, 'input> WsBindingOperation<'a, 'input> {
         );
 
         let port_type: WsPortType<'a, 'input> = binding.port_type()?;
-        let mut operations = port_type.operations()?;
 
-        operations
-            .try_find(|o| Ok(o.name()? == name))?
-            .ok_or(WsError::new(
-                self.0,
-                WsErrorType::MalformedWsdl(WsErrorMalformedType::MissingElement(name.to_string())),
-            ))
+        for op in port_type.operations()? {
+            if op.name()? == name {
+                return Ok(op);
+            }
+        }
+        Err(WsError::new(
+            self.0,
+            WsErrorType::MalformedWsdl(WsErrorMalformedType::MissingElement(name.to_string())),
+        ))
     }
 
     /// Return the XML node this struct is associated with


### PR DESCRIPTION
This replaces try_find with just a for loop to do the same thing and updates the deps and gets the test/example in the README.md compiling again as it was broken before.