### PR TITLE
Add multi-return function variants for outputs and faults on operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsdl"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Idiomatic Rust wrapper for WSDL"
 keywords = ["wsdl"]
@@ -12,9 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roxmltree = "0.18"
-thiserror = "1.0.44"
+roxmltree = "0.20"
+thiserror = "1.0.63"
 
 [dev-dependencies]
-anyhow = "1.0.72"
-clap = "4.3"
+anyhow = "1.0.87"
+clap = "4.5.17"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rust newtypes to expose a native interface for reading WSDL files.
 ## Usage
 ```rust
 # use anyhow::Result;
-use wsdl::Wsdl;
+use wsdl::WsDefinitions;
 
 fn example() -> Result<()> {
     let input = std::fs::read_to_string("/path/to/my/service.wsdl")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![feature(try_find)]
 mod wsdl;
 
 pub use self::wsdl::{

--- a/src/wsdl.rs
+++ b/src/wsdl.rs
@@ -128,7 +128,7 @@ impl<'a, 'input> WsMessage<'a, 'input> {
     }
 
     /// Retrieve the parts of this message.
-    pub fn parts(&self) -> impl Iterator<Item = WsMessagePart> {
+    pub fn parts(&self) -> impl Iterator<Item = WsMessagePart<'a, 'input>> {
         self.0
             .children()
             .filter(|n| n.has_tag_name(("http://schemas.xmlsoap.org/wsdl/", "part")))

--- a/src/wsdl.rs
+++ b/src/wsdl.rs
@@ -9,6 +9,8 @@ pub enum WsErrorMalformedType {
     MissingAttribute(String),
     #[error("missing element \"{0}\"")]
     MissingElement(String),
+    #[error("too many elements \"{0}\"")]
+    TooManyElements(String),
 }
 
 #[derive(Error, Debug)]
@@ -227,39 +229,49 @@ impl<'a, 'input> WsPortOperation<'a, 'input> {
 
     /// Retrieve the input message for this port.
     pub fn input(&self) -> Result<Option<WsMessage<'a, 'input>>> {
-        let message_typename = match self
-            .0
-            .children()
-            .find(|n| n.has_tag_name(("http://schemas.xmlsoap.org/wsdl/", "input")))
-            .map(|n| n.attribute("message"))
-            .flatten()
-        {
-            Some(n) => n,
-            None => return Ok(None),
+        let mut inputs = self.inputs()?;
+        let Some(input) = inputs.next() else {
+            return Ok(None);
         };
+        if let Some((name, extra)) = inputs.next() {
+            return Err(WsError::new(extra.node(), WsErrorType::MalformedWsdl(WsErrorMalformedType::TooManyElements(format!("extra `inputs` element of: {name}")))))
+        }
+        Ok(Some(input.1))
+    }
 
-        let (_message_namespace, message_name) =
-            split_qualified(message_typename).map_err(|e| WsError::new(self.0, e))?;
-
+    /// Only a single input is allowed to exist so this is non-public.
+    fn inputs(&self) -> Result<impl Iterator<Item=(&'a str, WsMessage<'a, 'input>)>> {
         let def = WsDefinitions::find_parent(self.0)?;
-        Ok(Some(
-            def.messages()?
-                .find(|n| n.0.attribute("name") == Some(message_name))
-                .ok_or(WsError::new(
-                    self.0,
-                    WsErrorType::InvalidReference(message_name.to_string()),
-                ))?,
-        ))
+        Ok(self
+           .0
+           .children()
+           .filter(|n| n.has_tag_name(("http://schemas.xmlsoap.org/wsdl/", "input")))
+           .filter_map(|n| Some((n.attribute("name")?, n.attribute("message")?)))
+           .filter_map(|(name, message_typename)| match split_qualified(message_typename) {
+               Ok((_message_namespace, message_name)) => Some((name, message_name)),
+               Err(_) => None
+           }).filter_map(move |(name, message_name)| {
+            let Ok(mut messages) = def.messages() else {
+                return None;
+            };
+            if let Some(message) = messages.find(|n| n.0.attribute("name") == Some(message_name)) {
+                Some((name, message))
+            } else {
+                None
+            }
+        }))
     }
 
     /// Retrieve the output message for this port.
     pub fn output(&self) -> Result<Option<WsMessage<'a, 'input>>> {
         let mut outputs = self.outputs()?;
-        let output = outputs.next();
-        if outputs.next().is_some() {
-            panic!("Multiple output messages found for operation {:?}", self.name()?);
+        let Some(output) = outputs.next() else {
+            return Ok(None);
+        };
+        if let Some((name, extra)) = outputs.next() {
+            return Err(WsError::new(extra.node(), WsErrorType::MalformedWsdl(WsErrorMalformedType::TooManyElements(format!("extra `output` element of: {name}")))))
         }
-         Ok(output.map(|(_, m)| m))
+        Ok(Some(output.1))
     }
 
     /// Only a single output is allowed to exist so this is non-public.

--- a/src/wsdl.rs
+++ b/src/wsdl.rs
@@ -335,14 +335,16 @@ impl<'a, 'input> WsBindingOperation<'a, 'input> {
         );
 
         let port_type: WsPortType<'a, 'input> = binding.port_type()?;
-        let mut operations = port_type.operations()?;
 
-        operations
-            .try_find(|o| Ok(o.name()? == name))?
-            .ok_or(WsError::new(
-                self.0,
-                WsErrorType::MalformedWsdl(WsErrorMalformedType::MissingElement(name.to_string())),
-            ))
+        for op in port_type.operations()? {
+            if op.name()? == name {
+                return Ok(op);
+            }
+        }
+        Err(WsError::new(
+            self.0,
+            WsErrorType::MalformedWsdl(WsErrorMalformedType::MissingElement(name.to_string())),
+        ))
     }
 
     /// Return the XML node this struct is associated with

--- a/src/wsdl.rs
+++ b/src/wsdl.rs
@@ -262,8 +262,8 @@ impl<'a, 'input> WsPortOperation<'a, 'input> {
          Ok(output.map(|(_, m)| m))
     }
 
-    /// Retrieve all output messages for this port
-    pub fn outputs(&self) -> Result<impl Iterator<Item=(&'a str, WsMessage<'a, 'input>)>> {
+    /// Only a single output is allowed to exist so this is non-public.
+    fn outputs(&self) -> Result<impl Iterator<Item=(&'a str, WsMessage<'a, 'input>)>> {
         let def = WsDefinitions::find_parent(self.0)?;
         Ok(self
            .0

--- a/src/wsdl.rs
+++ b/src/wsdl.rs
@@ -259,11 +259,11 @@ impl<'a, 'input> WsPortOperation<'a, 'input> {
         if outputs.next().is_some() {
             panic!("Multiple output messages found for operation {:?}", self.name()?);
         }
-         Ok(output)
+         Ok(output.map(|(_, m)| m))
     }
 
     /// Retrieve all output messages for this port
-    pub fn outputs(&self) -> Result<impl Iterator<Item=WsMessage<'a, 'input>>> {
+    pub fn outputs(&self) -> Result<impl Iterator<Item=(&'a str, WsMessage<'a, 'input>)>> {
         let def = WsDefinitions::find_parent(self.0)?;
         Ok(self
            .0
@@ -278,7 +278,7 @@ impl<'a, 'input> WsPortOperation<'a, 'input> {
                 return None;
             };
             if let Some(message) = messages.find(|n| n.0.attribute("name") == Some(message_name)) {
-                Some(message)
+                Some((name, message))
             } else {
                 None
             }
@@ -292,11 +292,11 @@ impl<'a, 'input> WsPortOperation<'a, 'input> {
         if faults.next().is_some() {
             panic!("Multiple fault messages found for operation {:?}", self.name()?);
         }
-        Ok(fault)
+        Ok(fault.map(|(_, m)| m))
     }
 
     /// Retrieve all fault messages for this port
-    pub fn faults(&self) -> Result<impl Iterator<Item=WsMessage<'a, 'input>>> {
+    pub fn faults(&self) -> Result<impl Iterator<Item=(&'a str, WsMessage<'a, 'input>)>> {
         let def = WsDefinitions::find_parent(self.0)?;
         Ok(self
            .0
@@ -311,7 +311,7 @@ impl<'a, 'input> WsPortOperation<'a, 'input> {
                 return None;
             };
             if let Some(message) = messages.find(|n| n.0.attribute("name") == Some(message_name)) {
-                Some(message)
+                Some((name, message))
             } else {
                 None
             }


### PR DESCRIPTION
Should fix #3, although I'm unsure if the old output/fault should return a new error variant instead of panicing on multiple results (definitely shouldn't just hide the rest for sure though).